### PR TITLE
Change workflows to use ubuntu-latest

### DIFF
--- a/.github/workflows/ci-registrations.yml
+++ b/.github/workflows/ci-registrations.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   mix-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     services:
       db:
         image: postgis/postgis:16-3.4

--- a/.github/workflows/ci-waydowntown-app.yml
+++ b/.github/workflows/ci-waydowntown-app.yml
@@ -34,7 +34,7 @@ jobs:
         working-directory: waydowntown_app
 
   test-android:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This probably won’t fix the Hound tests in CI but it’s a sensible choice regardless.